### PR TITLE
Add MAP mutator

### DIFF
--- a/cloudkitty/collector/gnocchi.py
+++ b/cloudkitty/collector/gnocchi.py
@@ -434,7 +434,9 @@ class GnocchiCollector(collector.BaseCollector):
         qty = data['measures']['measures']['aggregated'][0][2]
         converted_qty = ck_utils.convert_unit(
             qty, metconf['factor'], metconf['offset'])
-        mutated_qty = ck_utils.mutate(converted_qty, metconf['mutate'])
+        mutate_map = metconf.get('mutate_map')
+        mutated_qty = ck_utils.mutate(converted_qty, metconf['mutate'],
+                                      mutate_map=mutate_map)
         return metadata, groupby, mutated_qty
 
     def fetch_all(self, metric_name, start, end,

--- a/cloudkitty/collector/monasca.py
+++ b/cloudkitty/collector/monasca.py
@@ -199,7 +199,9 @@ class MonascaCollector(collector.BaseCollector):
         qty = data['statistics'][0][1]
         converted_qty = ck_utils.convert_unit(
             qty, metconf['factor'], metconf['offset'])
-        mutated_qty = ck_utils.mutate(converted_qty, metconf['mutate'])
+        mutate_map = metconf.get('mutate_map')
+        mutated_qty = ck_utils.mutate(converted_qty, metconf['mutate'],
+                                      mutate_map=mutate_map)
         return metadata, groupby, mutated_qty
 
     def fetch_all(self, metric_name, start, end,

--- a/cloudkitty/collector/prometheus.py
+++ b/cloudkitty/collector/prometheus.py
@@ -148,7 +148,9 @@ class PrometheusCollector(collector.BaseCollector):
                 self.conf[metric_name]['factor'],
                 self.conf[metric_name]['offset'],
             )
-            qty = ck_utils.mutate(qty, self.conf[metric_name]['mutate'])
+            mutate_map = self.conf[metric_name].get('mutate_map')
+            qty = ck_utils.mutate(qty, self.conf[metric_name]['mutate'],
+                                  mutate_map=mutate_map)
 
         return metadata, groupby, qty
 

--- a/cloudkitty/tests/collectors/test_validation.py
+++ b/cloudkitty/tests/collectors/test_validation.py
@@ -188,3 +188,26 @@ class MetricConfigValidationTest(tests.TestCase):
             self.assertRaises(
                 collector.InvalidConfiguration,
                 collector.check_duplicates, metric_name, metric)
+
+    def test_validate_map_mutator(self):
+        data = copy.deepcopy(self.base_data)
+
+        # Check that validation succeeds when MAP mutator is not used
+        for metric_name, metric in data['metrics'].items():
+            collector.validate_map_mutator(metric_name, metric)
+
+        # Check that validation raises an exception when mutate_map is missing
+        for metric_name, metric in data['metrics'].items():
+            metric['mutate'] = 'MAP'
+            self.assertRaises(
+                collector.InvalidConfiguration,
+                collector.validate_map_mutator, metric_name, metric)
+
+        data = copy.deepcopy(self.base_data)
+        # Check that validation raises an exception when mutate_map is present
+        # but MAP mutator is not used
+        for metric_name, metric in data['metrics'].items():
+            metric['mutate_map'] = {}
+            self.assertRaises(
+                collector.InvalidConfiguration,
+                collector.validate_map_mutator, metric_name, metric)

--- a/cloudkitty/utils/__init__.py
+++ b/cloudkitty/utils/__init__.py
@@ -251,8 +251,8 @@ def tempdir(**kwargs):
             LOG.debug('Could not remove tmpdir: %s', e)
 
 
-def mutate(value, mode='NONE'):
-    """Mutate value according provided mode."""
+def mutate(value, mode='NONE', mutate_map=None):
+    """Mutate value according to provided mode."""
 
     if mode == 'NUMBOOL':
         return float(value != 0.0)
@@ -265,6 +265,12 @@ def mutate(value, mode='NONE'):
 
     if mode == 'CEIL':
         return math.ceil(value)
+
+    if mode == 'MAP':
+        ret = 0.0
+        if mutate_map is not None:
+            ret = mutate_map.get(value, 0.0)
+        return ret
 
     return value
 

--- a/doc/source/admin/configuration/collector.rst
+++ b/doc/source/admin/configuration/collector.rst
@@ -177,7 +177,7 @@ Quantity mutation
 ~~~~~~~~~~~~~~~~~
 
 It is also possible to mutate the collected qty with the ``mutate`` option.
-Four values are accepted for this parameter:
+Five values are accepted for this parameter:
 
 * ``NONE``: This is the default. The collected data is not modifed.
 
@@ -189,6 +189,11 @@ Four values are accepted for this parameter:
 
 * ``NOTNUMBOOL``: If the collected qty equals 0, set it to 1. Else, set it to
   0.
+
+* ``MAP``: Map arbritrary values to new values as defined through the
+  ``mutate_map`` option (dictionary). If the value is not found in
+  ``mutate_map``, set it to 0. If ``mutate_map`` is not defined or is empty,
+  all values are set to 0.
 
 .. warning::
 
@@ -228,6 +233,26 @@ when the instance is in ACTIVE state but 4 if the instance is in ERROR state:
      openstack_nova_server_status:
        unit: instance
        mutate: NOTNUMBOOL
+       groupby:
+         - id
+       metadata:
+         - flavor_id
+
+The ``MAP`` mutator is useful when multiple statuses should be billabled. For
+example, the following Prometheus metric has a value of 0 when the instance is
+in ACTIVE state, but operators may want to rate other non-zero states:
+
+.. code-block:: yaml
+
+   metrics:
+     openstack_nova_server_status:
+       unit: instance
+       mutate: MAP
+       mutate_map:
+         0.0: 1.0  # ACTIVE
+         11.0: 1.0 # SHUTOFF
+         12.0: 1.0 # SUSPENDED
+         16.0: 1.0 # PAUSED
        groupby:
          - id
        metadata:

--- a/releasenotes/notes/map-mutator-632b8629c0482e94.yaml
+++ b/releasenotes/notes/map-mutator-632b8629c0482e94.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Adds a ``MAP`` mutator to map arbitrary values to new values. This is
+    useful with metrics reporting resource status as their value, but multiple
+    statuses are billable.


### PR DESCRIPTION
This mutator can map arbitrary values to new values. This is useful with
metrics reporting resource status as their value, but multiple statuses
are billable.

Change-Id: I8fcb9f2aa4ef23432089bfd6351a9c03ce3cf941
(cherry picked from commit c9340b35f67699fcae0fa95f799deb4ebf1f1c99)