### PR TITLE
Change ES backend to allow use with OpenSearch instead

### DIFF
--- a/cloudkitty/storage/v2/elasticsearch/client.py
+++ b/cloudkitty/storage/v2/elasticsearch/client.py
@@ -158,12 +158,9 @@ class ElasticsearchClient(object):
         :rtype: requests.models.Response
         """
         url = '/'.join(
-            (self._url, self._index_name, '_mapping', self._mapping_name))
-        # NOTE(peschk_l): This is done for compatibility with
-        # Elasticsearch 6 and 7.
-        param = {"include_type_name": "true"}
+            (self._url, self._index_name, self._mapping_name))
         return self._req(
-            self._sess.put, url, json.dumps(mapping), param, deserialize=False)
+            self._sess.post, url, json.dumps(mapping), {}, deserialize=False)
 
     def get_index(self):
         """Does a GET request against ES's index API.

--- a/cloudkitty/tests/storage/v2/elasticsearch/test_client.py
+++ b/cloudkitty/tests/storage/v2/elasticsearch/test_client.py
@@ -186,9 +186,9 @@ class TestElasticsearchClient(unittest.TestCase):
         with mock.patch.object(self.client, '_req') as rmock:
             self.client.put_mapping(mapping)
             rmock.assert_called_once_with(
-                self.client._sess.put,
-                'http://elasticsearch:9200/index_name/_mapping/test_mapping',
-                '{"a": "b"}', {'include_type_name': 'true'}, deserialize=False)
+                self.client._sess.post,
+                'http://elasticsearch:9200/index_name/test_mapping',
+                '{"a": "b"}', {}, deserialize=False)
 
     def test_get_index(self):
         with mock.patch.object(self.client, '_req') as rmock:

--- a/devstack/plugin.sh
+++ b/devstack/plugin.sh
@@ -301,27 +301,29 @@ function install_influx {
     sudo systemctl start influxdb || sudo systemctl restart influxdb
 }
 
-function install_elasticsearch_ubuntu {
-    sudo apt install -qy openjdk-8-jre
-    local elasticsearch_file=$(get_extra_file https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.8.3.deb)
-    sudo dpkg -i --skip-same-version ${elasticsearch_file}
+function install_opensearch_ubuntu {
+    local opensearch_file=$(get_extra_file https://artifacts.opensearch.org/releases/bundle/opensearch/2.5.0/opensearch-2.5.0-linux-x64.deb)
+    sudo dpkg -i --skip-same-version ${opensearch_file}
 }
 
-function install_elasticsearch_fedora {
-    sudo yum install -y java-1.8.0-openjdk
-    local elasticsearch_file=$(get_extra_file https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.8.3.rpm)
-    sudo yum localinstall -y ${elasticsearch_file}
+function install_opensearch_fedora {
+    local opensearch_file=$(get_extra_file https://artifacts.opensearch.org/releases/bundle/opensearch/2.5.0/opensearch-2.5.0-linux-x64.rpm)
+    sudo yum localinstall -y ${opensearch_file}
 }
 
-function install_elasticsearch {
+function install_opensearch {
     if is_ubuntu; then
-        install_elasticsearch_ubuntu
+        install_opensearch_ubuntu
     elif is_fedora; then
-        install_elasticsearch_fedora
+        install_opensearch_fedora
     else
         die $LINENO "Distribution must be Debian or Fedora-based"
     fi
-    sudo systemctl start elasticsearch || sudo systemctl restart elasticsearch
+    if ! sudo grep plugins.security.disabled /etc/opensearch/opensearch.yml >/dev/null; then
+        echo "plugins.security.disabled: true" | sudo tee -a /etc/opensearch/opensearch.yml >/dev/null
+    fi
+    sudo systemctl enable opensearch
+    sudo systemctl start opensearch || sudo systemctl restart opensearch
 }
 
 # install_cloudkitty() - Collect source and prepare


### PR DESCRIPTION
This allows an OpenSearch deployment to be used as the backend for CloudKitty, without the need to create and backport support in Kolla for the new opensearch backend name. 

i.e. you still should tell CloudKitty to use the elasticseach backend, but with OpenSearch actually deployed instead.