### PR TITLE
Apply 2024.1 backports from 2023.1

### DIFF
--- a/cloudkitty/collector/prometheus.py
+++ b/cloudkitty/collector/prometheus.py
@@ -212,6 +212,8 @@ class PrometheusCollector(collector.BaseCollector):
         if query_suffix:
             query = "{0} {1}".format(query, query_suffix)
 
+        LOG.debug("Calling Prometheus with query: %s", query)
+
         try:
             res = self._conn.get_instant(
                 query,

--- a/cloudkitty/storage/v2/elasticsearch/client.py
+++ b/cloudkitty/storage/v2/elasticsearch/client.py
@@ -98,14 +98,15 @@ class ElasticsearchClient(object):
         sources = []
         for elem in groupby:
             if elem == 'type':
-                sources.append({'type': {'terms': {'field': 'type'}}})
+                sources.append({'type': {'terms': {'field': 'type.keyword'}}})
             elif elem == 'time':
                 # Not doing a date_histogram aggregation because we don't know
                 # the period
                 sources.append({'begin': {'terms': {'field': 'start'}}})
                 sources.append({'end': {'terms': {'field': 'end'}}})
             else:
-                sources.append({elem: {'terms': {'field': 'groupby.' + elem}}})
+                field = 'groupby.' + elem + '.keyword'
+                sources.append({elem: {'terms': {'field': field}}})
 
         return {"sources": sources}
 

--- a/cloudkitty/storage/v2/elasticsearch/client.py
+++ b/cloudkitty/storage/v2/elasticsearch/client.py
@@ -158,12 +158,9 @@ class ElasticsearchClient(object):
         :rtype: requests.models.Response
         """
         url = '/'.join(
-            (self._url, self._index_name, '_mapping', self._mapping_name))
-        # NOTE(peschk_l): This is done for compatibility with
-        # Elasticsearch 6 and 7.
-        param = {"include_type_name": "true"}
+            (self._url, self._index_name, self._mapping_name))
         return self._req(
-            self._sess.put, url, json.dumps(mapping), param, deserialize=False)
+            self._sess.post, url, json.dumps(mapping), {}, deserialize=False)
 
     def get_index(self):
         """Does a GET request against ES's index API.

--- a/cloudkitty/storage/v2/elasticsearch/client.py
+++ b/cloudkitty/storage/v2/elasticsearch/client.py
@@ -225,7 +225,7 @@ class ElasticsearchClient(object):
         """Does a POST request against ES's bulk API
 
         The POST request will be done against
-        `/<index_name>/<mapping_name>/_bulk`
+        `/<index_name>/_bulk`
 
         The instruction will be appended before each term. For example,
         bulk_with_instruction('instr', ['one', 'two']) will produce::
@@ -246,7 +246,7 @@ class ElasticsearchClient(object):
             *[(instruction, json.dumps(term)) for term in terms]
         )) + '\n'
         url = '/'.join(
-            (self._url, self._index_name, self._mapping_name, '_bulk'))
+            (self._url, self._index_name, '_bulk'))
         return self._req(self._sess.post, url, data, None, deserialize=False)
 
     def bulk_index(self, terms):

--- a/cloudkitty/tests/storage/v2/elasticsearch/test_client.py
+++ b/cloudkitty/tests/storage/v2/elasticsearch/test_client.py
@@ -186,9 +186,9 @@ class TestElasticsearchClient(unittest.TestCase):
         with mock.patch.object(self.client, '_req') as rmock:
             self.client.put_mapping(mapping)
             rmock.assert_called_once_with(
-                self.client._sess.put,
-                'http://elasticsearch:9200/index_name/_mapping/test_mapping',
-                '{"a": "b"}', {'include_type_name': 'true'}, deserialize=False)
+                self.client._sess.post,
+                'http://elasticsearch:9200/index_name/test_mapping',
+                '{"a": "b"}', {}, deserialize=False)
 
     def test_get_index(self):
         with mock.patch.object(self.client, '_req') as rmock:

--- a/cloudkitty/tests/storage/v2/elasticsearch/test_client.py
+++ b/cloudkitty/tests/storage/v2/elasticsearch/test_client.py
@@ -86,9 +86,9 @@ class TestElasticsearchClient(unittest.TestCase):
         self.assertEqual(
             self.client._build_composite(['one', 'type', 'two']),
             {'sources': [
-                {'one': {'terms': {'field': 'groupby.one'}}},
-                {'type': {'terms': {'field': 'type'}}},
-                {'two': {'terms': {'field': 'groupby.two'}}},
+                {'one': {'terms': {'field': 'groupby.one.keyword'}}},
+                {'type': {'terms': {'field': 'type.keyword'}}},
+                {'two': {'terms': {'field': 'groupby.two.keyword'}}},
             ]},
         )
 

--- a/cloudkitty/tests/storage/v2/elasticsearch/test_client.py
+++ b/cloudkitty/tests/storage/v2/elasticsearch/test_client.py
@@ -259,7 +259,7 @@ class TestElasticsearchClient(unittest.TestCase):
             self.client.bulk_with_instruction(instruction, terms)
             rmock.assert_called_once_with(
                 self.client._sess.post,
-                'http://elasticsearch:9200/index_name/test_mapping/_bulk',
+                'http://elasticsearch:9200/index_name/_bulk',
                 expected_data, None, deserialize=False)
 
     def test_bulk_index(self):


### PR DESCRIPTION
Following commits were applied

Commit | Change-Id | Message
5888807e40 None Patch the elasticsearch backend too
e779115502 None Remove mapping name from bulk API URL
bbe93d4a4e I42aa30754e2d26a3953059b27b1f612ba5ae4150 Install OpenSearch 2.5.0 using packages
011085ebcb None Log Prometheus Query
